### PR TITLE
Fix success message grammar

### DIFF
--- a/templates/login.html.php
+++ b/templates/login.html.php
@@ -16,7 +16,7 @@
 
   
       <?php if (!empty($_SESSION['utilisateur-inscrit'])): ?>
-    <p id="success-message" class="message-success">✅ inscription fait avec succès.</p>
+    <p id="success-message" class="message-success">✅ inscription faite avec succès.</p>
     <?php unset($_SESSION['utilisateur-inscrit']); ?>
       <dialog open>
   <p> Bienvenue dans le Club Canin ! Veuillez vous connecter pour accéder à l'inscription chien !</p>


### PR DESCRIPTION
## Summary
- correct grammar in the login success message

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68532d072824832fa32c9f9d41ffd019