### PR TITLE
Fix deletion bug in admin page

### DIFF
--- a/public/admin.php
+++ b/public/admin.php
@@ -42,8 +42,11 @@ if (isset($_POST['supprimer_utilisateur'])) {
     // Ne pas permettre la suppression de soi-même
     if ($idUtilisateurASupprimer != $_SESSION['id_utilisateur']) {
 
-        $stmtDelete = $pdo->prepare("DELETE FROM chien WHERE id_utilisateur = :id_utilisateur; DELETE FROM utilisateur WHERE id_utilisateur = :id_utilisateur");
-        $stmtDelete->execute([':id_utilisateur' => $idUtilisateurASupprimer]);
+        $stmtDeleteChien = $pdo->prepare("DELETE FROM chien WHERE id_utilisateur = :id_utilisateur");
+        $stmtDeleteChien->execute([':id_utilisateur' => $idUtilisateurASupprimer]);
+
+        $stmtDeleteUtilisateur = $pdo->prepare("DELETE FROM utilisateur WHERE id_utilisateur = :id_utilisateur");
+        $stmtDeleteUtilisateur->execute([':id_utilisateur' => $idUtilisateurASupprimer]);
 
         $_SESSION['utilisateur_supprime'] = true;
     } else {


### PR DESCRIPTION
## Summary
- ensure deleting a user runs two separate SQL queries

## Testing
- `php -l public/admin.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68532beee334832fac196fde2064e4cd