### PR TITLE
Correction du tableau de bord

### DIFF
--- a/public/tableauBord.php
+++ b/public/tableauBord.php
@@ -119,7 +119,7 @@ $stmtUtilisateur = $pdo->prepare(
 "SELECT u.nom_utilisateur, u.email, u.nom, u.prenom FROM utilisateur WHERE u.id_utilisateur = :id_utilisateur
 
 ");
-$stmtUtilisateur->execute([':id_utilisateur'=> $idUtilisateur]);
+$stmtUtilisateur->execute([':id_utilisateur' => $id_utilisateur]);
 $utilisateurInfos=$stmtUtilisateur->fetch(PDO::FETCH_ASSOC);
 
 require_once __DIR__ . '/../templates/tableauBord.html.php';

--- a/templates/tableauBord.html.php
+++ b/templates/tableauBord.html.php
@@ -15,8 +15,8 @@
   <main>
     <h2>📊 Tableau de bord</h2>
 
-  <div class="card">
-        <h3>👤 Bienvenue, <?= hsc($utilisateurInfos['prenom']) ?> <?= hsc($utilisateurInfos['nom']) ?></h3>
+    <div class="card">
+      <h3>👤 Bienvenue, <?= hsc($utilisateurInfos['prenom']) ?> <?= hsc($utilisateurInfos['nom']) ?></h3>
       <p><strong>Nom d'utilisateur :</strong> <?= hsc($utilisateurInfos['nom_utilisateur']) ?> </p>
       <p><strong>Email :</strong> <?= hsc($utilisateurInfos['email']) ?></p>
     </div>

--- a/templates/tableauBord.html.php
+++ b/templates/tableauBord.html.php
@@ -15,8 +15,8 @@
   <main>
     <h2>📊 Tableau de bord</h2>
 
-    <div class="card">
-      <h3>👤 Bienvenue, <?= hsc($utilisateurInfos['nom']) ?> <?= hsc($utilisateurInfos['nom'])?></h3>
+  <div class="card">
+        <h3>👤 Bienvenue, <?= hsc($utilisateurInfos['prenom']) ?> <?= hsc($utilisateurInfos['nom']) ?></h3>
       <p><strong>Nom d'utilisateur :</strong> <?= hsc($utilisateurInfos['nom_utilisateur']) ?> </p>
       <p><strong>Email :</strong> <?= hsc($utilisateurInfos['email']) ?></p>
     </div>


### PR DESCRIPTION
## Résumé
- correction de la variable utilisée lors de la récupération des informations utilisateur
- affichage du prénom et du nom dans la vue du tableau de bord

## Tests
- `php -v` *(échoue : php non installé)*

------
https://chatgpt.com/codex/tasks/task_e_68533759a8b4832fbd4a3e98dbf23d9f